### PR TITLE
Deleted dependence_deploy variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ module "logging" {
 | elasticsearch_host           | The ES host where logs are going to be sent        | string   | false | yes |
 | elasticsearch_audit_host     | The ES audit host where logs are going to be sent  | string   | false | no |
 | dependence_prometheus        | Prometheus Dependence variable                     | string   |       | yes |
-| dependence_deploy            | Deploy (helm) dependence variable                  | string   |       | yes |
 | dependence_priority_classes  | Priority class dependence                          | string   |       | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,6 @@ resource "helm_release" "fluentd_es" {
 
   depends_on = [
     var.dependence_priority_classes,
-    var.dependence_deploy,
     var.dependence_prometheus
   ]
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-
-variable "dependence_deploy" {
-  description = "Deploy Module dependences - it is required in order to use this module."
-}
-
 variable "dependence_prometheus" {
   description = "Prometheus module dependence - it is required in order to use this module."
 }


### PR DESCRIPTION
This variable was needed when we were using Helm 2, it was the way to tell Helm Chart inside our terraform modules to wait for tiller before getting installed.

Now we are using Helm 3 and there is not tiller in the clusters.