### PR TITLE
Add elastic-search curator cronjob in logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Terraform module that deploys cloud-platform logging solution. It includes compo
 module "logging" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=0.0.1"
 
-  # This module requires helm and OPA already deployed
-  dependences = [
-    null_resource.deploy,
-    module.prometheus.helm_prometheus_operator_status,
-    null_resource.priority_classes,
-  ]
+  elasticsearch_host       = replace(terraform.workspace, "live", "") != terraform.workspace ? "cloud-platform-live-es-endpoint" : "placeholder-elasticsearch"
+  elasticsearch_audit_host = replace(terraform.workspace, "live", "") != terraform.workspace ? "cloud-platform-audit-es-endpoint" : ""
+
+  dependence_prometheus       = module.prometheus.helm_prometheus_operator_status
+  dependence_priority_classes = kubernetes_priority_class.node_critical
+  enable_curator_cronjob      = terraform.workspace == local.live_workspace ? true : false
 }
 ```
 
@@ -25,6 +25,7 @@ module "logging" {
 | elasticsearch_audit_host     | The ES audit host where logs are going to be sent  | string   | false | no |
 | dependence_prometheus        | Prometheus Dependence variable                     | string   |       | yes |
 | dependence_priority_classes  | Priority class dependence                          | string   |       | yes |
+| enable_curator_cronjob       | Enable elastic-search curator cronjob              | boolean  | false | yes |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,9 @@ variable "elasticsearch_host" {
 variable "elasticsearch_audit_host" {
   description = "The elasticsearch audit host where logs are going to be shipped"
 }
+
+variable "enable_curator_cronjob" {
+  description = "Enable or not elastic-search curator cronjob - which runs every day to delete indices older than 30 days"
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
This cronjob runs every day to delete indices older than 30 days.

This job is maintained in [Environments repo](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live-1.cloud-platform.service.justice.gov.uk/logging/elasticsearch-curator.yaml), moved here to logging module.