### PR TITLE
Updated source in curator cronjob to creation_date

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ locals {
                 --filter_list '[
                   {
                     "filtertype":"age",
-                    "source":"name",
+                    "source":"creation_date",
                     "direction":"older",
                     "unit":"days",
                     "unit_count":30


### PR DESCRIPTION
To fix error, required key not provided @ data['timestring']

https://www.elastic.co/guide/en/elasticsearch/client/curator/current/filtertype_age.html#_age_calculation