### PR TITLE
Update elasticsearch-curator filter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,8 +10,9 @@ locals {
                 --filter_list '[
                   {
                     "filtertype":"age",
-                    "source":"creation_date",
+                    "source":"name",
                     "direction":"older",
+                    "timestring": "%Y.%m.%d",
                     "unit":"days",
                     "unit_count":30
                   }


### PR DESCRIPTION
To use source as name and timestring,
this will delete the index older than 30 days with timestring "%Y.%m.%d"