### PR TITLE
fluentbit depends on Prometheus

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -151,6 +151,7 @@ resource "helm_release" "fluent_bit" {
   depends_on = [
     kubernetes_namespace.logging,
     kubernetes_config_map.fluent_bit_config
+    var.dependence_prometheus
   ]
 }
 


### PR DESCRIPTION
Fluentbit helm chart add ServiceMonitor and in order to do that it required Prometheus CRDs in place. 