### PR TITLE
Updated regex to match all ingress controllers pods

### DIFF
--- a/resources/input-kubernetes.config
+++ b/resources/input-kubernetes.config
@@ -9,7 +9,7 @@
 [INPUT]
     Name              tail
     Tag               nginx-ingress.*
-    Path              /var/log/containers/nginx-ingress-*.log
+    Path              /var/log/containers/*nx-*.log
     Parser            generic-json
     Refresh_Interval  5
     Mem_Buf_Limit     5MB


### PR DESCRIPTION
This update the regular expression in order to match all ingress controllers pods within ìngress-controllers` namespace