### PR TITLE
Add additional config in fluent-bit to parse eventrouter logs as json

### DIFF
--- a/resources/filter-kubernetes.config
+++ b/resources/filter-kubernetes.config
@@ -7,17 +7,6 @@
     Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
     K8S-Logging.Parser  On
     K8S-Logging.Exclude On
-    Merge_Log           On
-    Merge_Log_Key       log_processed 
-[FILTER]
-    Name                kubernetes
-    Match               kubernetes-infra.*
-    Kube_Tag_Prefix     kubernetes.var.log.containers.
-    Kube_URL            https://kubernetes.default.svc:443
-    Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-    K8S-Logging.Parser  On
-    K8S-Logging.Exclude On
     Merge_Log           Off
 [FILTER]
     Name                kubernetes

--- a/resources/filter-kubernetes.config
+++ b/resources/filter-kubernetes.config
@@ -10,6 +10,17 @@
     Merge_Log           Off
 [FILTER]
     Name                kubernetes
+    Match               eventrouter.*
+    Kube_Tag_Prefix     eventrouter.var.log.containers.eventrouter*
+    Kube_URL            https://kubernetes.default.svc:443
+    Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
+    K8S-Logging.Parser  On
+    K8S-Logging.Exclude On
+    Merge_Log           On
+    Merge_Log_Key       log_processed
+[FILTER]
+    Name                kubernetes
     Match               nginx-ingress.*
     Kube_Tag_Prefix     nginx-ingress.var.log.containers.nginx-ingress*
     Kube_URL            https://kubernetes.default.svc:443

--- a/resources/filter-kubernetes.config
+++ b/resources/filter-kubernetes.config
@@ -7,6 +7,17 @@
     Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
     K8S-Logging.Parser  On
     K8S-Logging.Exclude On
+    Merge_Log           On
+    Merge_Log_Key       log_processed 
+[FILTER]
+    Name                kubernetes
+    Match               kubernetes-infra.*
+    Kube_Tag_Prefix     kubernetes.var.log.containers.
+    Kube_URL            https://kubernetes.default.svc:443
+    Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
+    K8S-Logging.Parser  On
+    K8S-Logging.Exclude On
     Merge_Log           Off
 [FILTER]
     Name                kubernetes

--- a/resources/input-kubernetes.config
+++ b/resources/input-kubernetes.config
@@ -2,6 +2,16 @@
     Name              tail
     Tag               kubernetes.*
     Path              /var/log/containers/*.log
+    Exclude_Path      *nx-*.log,eventrouter-*.log,prometheus-operator-*.log,opa-*.log, kube-proxy-*.log, *kiam_kiam*.log,*logging_fluent*.log
+    Parser            docker
+    Refresh_Interval  5
+    Mem_Buf_Limit     5MB
+    Skip_Long_Lines   On
+[INPUT]
+    Name              tail
+    Tag               kubernetes-infra.*
+    Path              /var/log/containers/*.log
+    Exclude_Path      *nx-*.log,eventrouter-*.log
     Parser            docker
     Refresh_Interval  5
     Mem_Buf_Limit     5MB

--- a/resources/input-kubernetes.config
+++ b/resources/input-kubernetes.config
@@ -13,3 +13,10 @@
     Parser            generic-json
     Refresh_Interval  5
     Mem_Buf_Limit     5MB
+[INPUT]
+    Name              tail
+    Tag               eventrouter.*
+    Path              /var/log/containers/eventrouter-*.log
+    Parser            generic-json
+    Refresh_Interval  5
+    Mem_Buf_Limit     5MB

--- a/resources/input-kubernetes.config
+++ b/resources/input-kubernetes.config
@@ -2,15 +2,6 @@
     Name              tail
     Tag               kubernetes.*
     Path              /var/log/containers/*.log
-    Exclude_Path      *nx-*.log,eventrouter-*.log,prometheus-operator-*.log,opa-*.log, kube-proxy-*.log, *kiam_kiam*.log,*logging_fluent*.log
-    Parser            docker
-    Refresh_Interval  5
-    Mem_Buf_Limit     5MB
-    Skip_Long_Lines   On
-[INPUT]
-    Name              tail
-    Tag               kubernetes-infra.*
-    Path              /var/log/containers/*.log
     Exclude_Path      *nx-*.log,eventrouter-*.log
     Parser            docker
     Refresh_Interval  5

--- a/resources/output-elasticsearch.config
+++ b/resources/output-elasticsearch.config
@@ -1,17 +1,5 @@
 [OUTPUT]
     Name            es
-    Match           kubernetes-infra.*
-    Host            ${elasticsearch_host}
-    Port            443
-    Type            _doc
-    Time_Key        @timestamp
-    Logstash_Prefix kubernetes_infra
-    tls             On
-    Logstash_Format On
-    Replace_Dots    On
-    Retry_Limit     False
-[OUTPUT]
-    Name            es
     Match           kubernetes.*
     Host            ${elasticsearch_host}
     Port            443

--- a/resources/output-elasticsearch.config
+++ b/resources/output-elasticsearch.config
@@ -22,3 +22,15 @@
     Logstash_Format On
     Replace_Dots    On
     Retry_Limit     False
+[OUTPUT]
+    Name            es
+    Match           eventrouter.*
+    Host            ${elasticsearch_host}
+    Port            443
+    Type            _doc
+    Time_Key        @timestamp
+    Logstash_Prefix eventrouter
+    tls             On
+    Logstash_Format On
+    Replace_Dots    On
+    Retry_Limit     False

--- a/resources/output-elasticsearch.config
+++ b/resources/output-elasticsearch.config
@@ -1,6 +1,18 @@
 [OUTPUT]
     Name            es
-    Match           *
+    Match           kubernetes-infra.*
+    Host            ${elasticsearch_host}
+    Port            443
+    Type            _doc
+    Time_Key        @timestamp
+    Logstash_Prefix kubernetes_infra
+    tls             On
+    Logstash_Format On
+    Replace_Dots    On
+    Retry_Limit     False
+[OUTPUT]
+    Name            es
+    Match           kubernetes.*
     Host            ${elasticsearch_host}
     Port            443
     Type            _doc


### PR DESCRIPTION
This PR will add a seperate data pipeline in fluent-bit to parse eventrouter logs. It uses 'generic-json' parser, collect logs from path '/var/log/containers/eventrouter-*.log' and pushes to elasticsearch with prefix 'eventrouter'

Related to: https://github.com/ministryofjustice/cloud-platform/issues/2252