### PR TITLE
Updated LimitRange so k8s don't keep changing `1000m` -> `1`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -259,7 +259,7 @@ resource "kubernetes_limit_range" "default" {
     limit {
       type = "Container"
       default = {
-        cpu    = "1000m"
+        cpu    = "1"
         memory = "1000Mi"
       }
       default_request = {


### PR DESCRIPTION
The divergence pipeline is failing with:

```
      ~ spec {
          ~ limit {
              ~ default                 = {
                  ~ "cpu"    = "1" -> "1000m"
                    "memory" = "1000Mi"
                }
```
