### PR TITLE
Increase pod limit to 100 for logging namespace

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -241,7 +241,7 @@ resource "kubernetes_resource_quota" "namespace_quota" {
   }
   spec {
     hard = {
-      pods = 50
+      pods = 100
     }
   }
 }


### PR DESCRIPTION
As we have fluent-bit and fluentd daemonsets running in logging namespace