### PR TITLE
Send everything (every single log) to the audit ES server

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,8 @@ resource "kubernetes_config_map" "fluent_bit_config" {
     "filter-kubernetes.conf" = file("${path.module}/resources/filter-kubernetes.config"),
     "parsers.conf"           = file("${path.module}/resources/parsers.config"),
     "output-elasticsearch.conf" = templatefile("${path.module}/resources/output-elasticsearch.config", {
-      elasticsearch_host = var.elasticsearch_host
+      elasticsearch_host       = var.elasticsearch_host
+      elasticsearch_audit_host = var.elasticsearch_audit_host
     })
   }
 

--- a/resources/output-elasticsearch.config
+++ b/resources/output-elasticsearch.config
@@ -34,3 +34,15 @@
     Logstash_Format On
     Replace_Dots    On
     Retry_Limit     False
+[OUTPUT]
+    Name            es
+    Match           *
+    Host            ${elasticsearch_audit_host}
+    Port            443
+    Type            _doc
+    Time_Key        @timestamp
+    Logstash_Prefix all_logs
+    tls             On
+    Logstash_Format On
+    Replace_Dots    On
+    Retry_Limit     False


### PR DESCRIPTION
In order to decommission fluentd we need to ensure fluent-bit also sends all the logs to the ElasticSearch audit server. This PR does that. 