### PR TITLE
Add ingress-node toleration to fluent-bit so it scrap the logs from N…

### DIFF
--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -16,3 +16,7 @@ tolerations:
     operator: "Equal"
     value: "true"
     effect: "NoSchedule"
+  - key: "ingress-node"
+    operator: "Equal"
+    value: "true"
+    effect: "NoSchedule" 


### PR DESCRIPTION
This is needed to scrap the logs from NodeGroup ingress-nodes-*

This is to check the logs of ingresses that are moved to fallback ingress controller to check connection timeout issues.