### PR TITLE
Pin Python version in alpine image

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,7 @@ resource "kubernetes_cron_job" "elasticsearch_curator_cronjob" {
           spec {
             container {
               name    = "curator"
-              image   = "python:alpine"
+              image   = "python:3.8.7-alpine3.13"
               command = ["/bin/sh", "-c", local.delete_indices]
             }
             restart_policy = "OnFailure"


### PR DESCRIPTION
An issue occurred whereby the cli version of elasticsearch_curator
doesn't run on python3.9. This wasn't captured and subsequently we ran
out of space in our Elasticsearch cluster. This commit pins the working
version of Python3 in the image.