### PR TITLE
Update prefix for index using cluster name

### DIFF
--- a/resources/output-elasticsearch.config
+++ b/resources/output-elasticsearch.config
@@ -5,7 +5,7 @@
     Port            443
     Type            _doc
     Time_Key        @timestamp
-    Logstash_Prefix kubernetes_cluster_${cluster}
+    Logstash_Prefix ${cluster}_kubernetes_cluster
     tls             On
     Logstash_Format On
     Replace_Dots    On
@@ -17,7 +17,7 @@
     Port            443
     Type            _doc
     Time_Key        @timestamp
-    Logstash_Prefix kubernetes_ingress_${cluster}
+    Logstash_Prefix ${cluster}_kubernetes_ingress
     tls             On
     Logstash_Format On
     Replace_Dots    On
@@ -29,7 +29,7 @@
     Port            443
     Type            _doc
     Time_Key        @timestamp
-    Logstash_Prefix eventrouter_${cluster}
+    Logstash_Prefix ${cluster}_eventrouter
     tls             On
     Logstash_Format On
     Replace_Dots    On


### PR DESCRIPTION
This will fix index issue, as kubernetes_cluster_live* also serves kubernetes_cluster_live-1*.

This change will have a cluster name at the front so it will fix the above issue.