### PR TITLE
Pin elasticsearch-curator 5.8.3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,12 @@
 
 locals {
   delete_indices = <<-EOF
-    pip3 install elasticsearch-curator &&
+    pip3 install elasticsearch-curator==5.8.3 &&
     (curator_cli \
       --host ${var.elasticsearch_host} \
       --use_ssl \
       --port 443 \
-      delete-indices \
+      delete_indices \
       --filter_list '[
         {
           "filtertype":"age",


### PR DESCRIPTION
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/3255 and relates to a temporary solution to the error:

```bash
2021-10-08 16:21:47,587 ERROR     Unable to connect to Elasticsearch cluster. Error: The client noticed that the server is not a supported distribution of Elasticsearch
2021-10-08 16:21:47,587 CRITICAL  Curator cannot proceed. Exiting.
```

When merged this fix will remove a number of Elasticsearc/opensearch indexes and free up necessary disk space.

Version 5.8.4 is enabled for either OpenSearch (new AWS ES) 1.0, via a
[backwards compatibility flag](https://github.com/elastic/curator/commit/191de8cd0c7c719de6d5fca1f9fbbc8adfb5c006#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552R2) or on ElasticSearch products only.

This leaves us two choices:
- pin the old version and attempt to find a more permanent solution.
- upgrade to OpenSearch 1.0 and upgrade to 5.8.4 as the [last functioning curator release](https://github.com/elastic/elasticsearch-py/commit/12c869df56e644863f05c74faa19151416b22aa2).

The AWS OpenSearch project is aware of the need to create/fork of the
curator.

This commit is a temporary fix until the community can find a more
permanent solution.