### PR TITLE
Fluent bit alert

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,6 +79,7 @@ resource "kubernetes_cron_job" "elasticsearch_curator_cronjob" {
       metadata {}
       spec {
         backoff_limit = 2
+        ttl_seconds_after_finished = 172800
         template {
           metadata {}
           spec {

--- a/main.tf
+++ b/main.tf
@@ -233,3 +233,10 @@ resource "kubernetes_limit_range" "default" {
     }
   }
 }
+
+#########################
+# prometheus rule alert #
+#########################
+resource "kubectl_manifest" "prometheus_rule_alert" {
+    yaml_body = file("${path.module}/resources/prometheusrule-alerts/alerts.yaml")
+}

--- a/resources/prometheusrule-alerts/alerts.yaml
+++ b/resources/prometheusrule-alerts/alerts.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: fluent-bit-errors
+  namespace: logging
+  labels:
+    prometheus: cloud-platform
+spec:
+  groups:
+  - name: fluentbit
+    rules:
+    - alert: FluentbitTooManyErrors
+      expr: rate(fluentbit_output_retries_failed_total[10m]) > 0
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        message: Fluentbit is erroring. Check the logs.

--- a/resources/prometheusrule-alerts/alerts.yaml
+++ b/resources/prometheusrule-alerts/alerts.yaml
@@ -11,7 +11,7 @@ spec:
   - name: fluentbit
     rules:
     - alert: FluentbitTooManyErrors
-      expr: rate(fluentbit_output_retries_failed_total[10m]) > 0
+      expr: rate(fluentbit_output_retries_failed_total[10m]) > 10
       for: 10m
       labels:
         severity: warning

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,6 @@ terraform {
     }
     kubectl = {
       source  = "gavinbunney/kubectl"
-      version = "1.11.2"
     }
   }
   required_version = ">= 0.13"

--- a/versions.tf
+++ b/versions.tf
@@ -6,6 +6,10 @@ terraform {
     kubernetes = {
       source = "hashicorp/kubernetes"
     }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "1.11.2"
+    }
   }
   required_version = ">= 0.13"
 }


### PR DESCRIPTION
- Add prometheus_rule_alert for fluent bit. This is to alert when "fluentbit_output_retries_failed_total" > 0
- Add ttl_seconds_after_finished for curator cronjob. This is to keep the job for 2 days, to get alert when failed, as clear completed jobs clean the jobs without ttl.