### PR TITLE
Add helm dependency for prometheus_rule_alert

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ resource "kubernetes_cron_job" "elasticsearch_curator_cronjob" {
     job_template {
       metadata {}
       spec {
-        backoff_limit = 2
+        backoff_limit              = 2
         ttl_seconds_after_finished = 172800
         template {
           metadata {}
@@ -239,5 +239,6 @@ resource "kubernetes_limit_range" "default" {
 # prometheus rule alert #
 #########################
 resource "kubectl_manifest" "prometheus_rule_alert" {
-    yaml_body = file("${path.module}/resources/prometheusrule-alerts/alerts.yaml")
+  depends_on = [helm_release.fluent_bit]
+  yaml_body  = file("${path.module}/resources/prometheusrule-alerts/alerts.yaml")
 }

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
+      source = "gavinbunney/kubectl"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
Add helm dependency for prometheus_rule_alert, as prometheus_rule_alert have a dependency for Prometheus, and fluent-bit helm deployment already got a dependency on Prometheus.