### PR TITLE
bigger audit buffers

### DIFF
--- a/resources/input-kubernetes.config
+++ b/resources/input-kubernetes.config
@@ -28,3 +28,5 @@
     Parser            docker
     Refresh_Interval  5
     Mem_Buf_Limit     5MB
+    Buffer_Max_Size   5MB
+    Buffer_Chunk_Size 1M


### PR DESCRIPTION
Noticed 
```
fluent-bit-9dwzv fluent-bit [2021/11/10 11:20:12] [error] [in_tail] file=/var/log/kube-apiserver-audit.log requires a larger buffer size, lines are too long. Skipping file.
```
in logs