### PR TITLE
Increased buffer size to 1MB, default is 32k

### DIFF
--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -88,6 +88,7 @@ config:
         K8S-Logging.Parser  On
         K8S-Logging.Exclude On
         Merge_Log           Off
+        Buffer_Size         1MB
     [FILTER]
         Name                kubernetes
         Match               eventrouter.*
@@ -99,6 +100,7 @@ config:
         K8S-Logging.Exclude On
         Merge_Log           On
         Merge_Log_Key       log_processed
+        Buffer_Size         1MB
     [FILTER]
         Name                kubernetes
         Match               nginx-ingress.*
@@ -110,6 +112,7 @@ config:
         K8S-Logging.Exclude On
         Merge_Log           On
         Merge_Log_Key       log_processed
+        Buffer_Size         1MB
     [FILTER]
         Name                kubernetes
         Match               nginx-ingress-modsec.*
@@ -121,6 +124,7 @@ config:
         K8S-Logging.Exclude On
         Merge_Log           On
         Merge_Log_Key       log_processed
+        Buffer_Size         1MB
 
   ## https://docs.fluentbit.io/manual/pipeline/outputs
   outputs: |


### PR DESCRIPTION
This is to fix the warning:
cannot increase buffer: current=32000 requested=64768 max=32000

This is fixed in release 1.8.7( https://github.com/fluent/fluent-bit/issues/3900), 
but we can't go to that version yet, as we have an open issue related to DNS (
https://github.com/fluent/fluent-bit/issues/4260)
