### PR TITLE
Bump eventrouter chart to 0.3.3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ resource "helm_release" "eventrouter" {
   repository = "https://ministryofjustice.github.io/cloud-platform-helm-charts"
   chart      = "eventrouter"
   namespace  = kubernetes_namespace.logging.id
+  version = "0.3.3"
 
   set {
     name  = "sink"


### PR DESCRIPTION
Related to: https://github.com/ministryofjustice/cloud-platform/issues/4176

Include version when installing the helm chart. By default, helm installs the latest version for new clusters. But for existing clusters live, manager etc, it doesnot fetch the latest chart unless the version is specified. 