### PR TITLE
Modsec audit data redacting and multiple output streams

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.14.x
+          terraform_version: 1.2.5
           terraform_wrapper: false
 
       - name: Run tf Tests

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ No modules.
 | <a name="input_dependence_prometheus"></a> [dependence\_prometheus](#input\_dependence\_prometheus) | Prometheus module dependence - it is required in order to use this module. | `any` | n/a | yes |
 | <a name="input_elasticsearch_audit_host"></a> [elasticsearch\_audit\_host](#input\_elasticsearch\_audit\_host) | The elasticsearch audit host where logs are going to be shipped | `any` | n/a | yes |
 | <a name="input_elasticsearch_host"></a> [elasticsearch\_host](#input\_elasticsearch\_host) | The elasticsearch host where logs are going to be shipped | `any` | n/a | yes |
+| <a name="input_elasticsearch_modsec_audit_host"></a> [elasticsearch\_modsec\_audit\_host](#input\_elasticsearch\_modsec\_audit\_host) | The elasticsearch host where modsec audit logs are going to be shipped | `any` | n/a | yes |
 | <a name="input_enable_curator_cronjob"></a> [enable\_curator\_cronjob](#input\_enable\_curator\_cronjob) | Enable or not elastic-search curator cronjob - which runs every day to delete indices older than 30 days | `bool` | `false` | no |
 | <a name="input_enable_fluent_bit"></a> [enable\_fluent\_bit](#input\_enable\_fluent\_bit) | Enable or not fluent-bit Helm Chart - change the default to true once it is ready to use | `bool` | `true` | no |
 

--- a/examples/logging.tf
+++ b/examples/logging.tf
@@ -8,6 +8,7 @@ module "logging" {
 
   elasticsearch_host       = "placeholder-elasticsearch"
   elasticsearch_audit_host = ""
+  elasticsearch_modsec_audit_host = ""
 
   dependence_prometheus  = "status"
   enable_curator_cronjob = false

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,7 @@ resource "helm_release" "fluent_bit" {
   values = [templatefile("${path.module}/templates/fluent-bit.yaml.tpl", {
     elasticsearch_host       = var.elasticsearch_host
     elasticsearch_audit_host = var.elasticsearch_audit_host
+    elasticsearch_modsec_audit_host = var.elasticsearch_modsec_audit_host
     cluster                  = terraform.workspace
     fluentbit_app_version    = "1.8.4" # Pinned to version, because of this issue https://github.com/fluent/fluent-bit/issues/4260
   })]

--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -134,6 +134,11 @@ config:
         Merge_Log           On
         Merge_Log_Key       log_processed
         Buffer_Size         1MB
+    # Include only Modsecurity audit logs
+    [FILTER]
+        Name    grep
+        Match   cp-ingress-modsec.*
+        regex   log (modsecurity|OWASP_CRS|owasp-modsecurity-crs)
     [FILTER]
         Name                kubernetes
         Match               cp-ingress-modsec.*

--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -121,6 +121,7 @@ config:
         Replace_Dots    On
         Generate_ID     On
         Retry_Limit     False
+        Suppress_Type_Name On
     [OUTPUT]
         Name            es
         Match           nginx-ingress.*
@@ -134,6 +135,7 @@ config:
         Replace_Dots    On
         Generate_ID     On
         Retry_Limit     False
+        Suppress_Type_Name On
     [OUTPUT]
         Name            es
         Match           eventrouter.*
@@ -147,6 +149,7 @@ config:
         Replace_Dots    On
         Generate_ID     On
         Retry_Limit     False
+        Suppress_Type_Name On
     [OUTPUT]
         Name            es
         Match           kube-apiserver-audit.*
@@ -160,6 +163,7 @@ config:
         Replace_Dots    On
         Generate_ID     On
         Retry_Limit     5
+        Suppress_Type_Name On
 
   ## https://docs.fluentbit.io/manual/pipeline/parsers
   customParsers: |

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,10 @@ variable "elasticsearch_host" {
   description = "The elasticsearch host where logs are going to be shipped"
 }
 
+variable "elasticsearch_modsec_audit_host" {
+  description = "The elasticsearch host where modsec audit logs are going to be shipped"
+}
+
 variable "elasticsearch_audit_host" {
   description = "The elasticsearch audit host where logs are going to be shipped"
 }


### PR DESCRIPTION
Related to: https://github.com/ministryofjustice/cloud-platform/issues/4439
This PR:
- Add a seperate tag, filter just modsec audit logs based on regex and stream to another Opensearch
- Filter the ingress logs to pattern match specific strings which are in modsec audit log using lua script and redact it