### PR TITLE
Increase timout for fluent-bit chart for long wait

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,7 @@ resource "helm_release" "fluent_bit" {
   repository = "https://fluent.github.io/helm-charts"
   namespace  = kubernetes_namespace.logging.id
   version    = "0.16.4"
+  timeout = 900
 
   values = [templatefile("${path.module}/templates/fluent-bit.yaml.tpl", {
     elasticsearch_host       = var.elasticsearch_host


### PR DESCRIPTION
This PR increase a wait timeout which allows the fluent-bit chart to apply on clusters which has lot of nodes e.g. live.