### PR TITLE
Remove integration for pushing `kube-apiserver-audit` logs into ElasticSearch, as these are now stored in CloudWatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_dependence_prometheus"></a> [dependence\_prometheus](#input\_dependence\_prometheus) | Prometheus module dependence - it is required in order to use this module. | `any` | n/a | yes |
-| <a name="input_elasticsearch_audit_host"></a> [elasticsearch\_audit\_host](#input\_elasticsearch\_audit\_host) | The elasticsearch audit host where logs are going to be shipped | `any` | n/a | yes |
 | <a name="input_elasticsearch_host"></a> [elasticsearch\_host](#input\_elasticsearch\_host) | The elasticsearch host where logs are going to be shipped | `any` | n/a | yes |
 | <a name="input_elasticsearch_modsec_audit_host"></a> [elasticsearch\_modsec\_audit\_host](#input\_elasticsearch\_modsec\_audit\_host) | The elasticsearch host where modsec audit logs are going to be shipped | `any` | n/a | yes |
-| <a name="input_enable_curator_cronjob"></a> [enable\_curator\_cronjob](#input\_enable\_curator\_cronjob) | Enable or not elastic-search curator cronjob - which runs every day to delete indices older than 30 days | `bool` | `false` | no |
 | <a name="input_enable_fluent_bit"></a> [enable\_fluent\_bit](#input\_enable\_fluent\_bit) | Enable or not fluent-bit Helm Chart - change the default to true once it is ready to use | `bool` | `true` | no |
 
 ## Outputs

--- a/examples/logging.tf
+++ b/examples/logging.tf
@@ -6,11 +6,9 @@
 module "logging" {
   source = "../"
 
-  elasticsearch_host       = "placeholder-elasticsearch"
-  elasticsearch_audit_host = ""
+  elasticsearch_host              = "placeholder-elasticsearch"
   elasticsearch_modsec_audit_host = ""
 
-  dependence_prometheus  = "status"
-  enable_curator_cronjob = false
-  enable_fluent_bit      = false
+  dependence_prometheus = "status"
+  enable_fluent_bit     = false
 }

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,6 @@ resource "helm_release" "fluent_bit" {
 
   values = [templatefile("${path.module}/templates/fluent-bit.yaml.tpl", {
     elasticsearch_host              = var.elasticsearch_host
-    elasticsearch_audit_host        = var.elasticsearch_audit_host
     elasticsearch_modsec_audit_host = var.elasticsearch_modsec_audit_host
     cluster                         = terraform.workspace
     fluentbit_app_version           = "1.8.4" # Pinned to version, because of this issue https://github.com/fluent/fluent-bit/issues/4260

--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -232,19 +232,6 @@ config:
         Replace_Dots    On
         Generate_ID     On
         Retry_Limit     False
-    [OUTPUT]
-        Name            es
-        Match           kube-apiserver-audit.*
-        Host            ${elasticsearch_audit_host}
-        Port            443
-        Type            _doc
-        Time_Key        @timestamp
-        Logstash_Prefix kubeapi_audit
-        tls             On
-        Logstash_Format On
-        Replace_Dots    On
-        Generate_ID     On
-        Retry_Limit     5
 
   ## https://docs.fluentbit.io/manual/pipeline/parsers
   customParsers: |
@@ -268,4 +255,3 @@ config:
         Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
         Time_Key    time
         Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-

--- a/variables.tf
+++ b/variables.tf
@@ -10,18 +10,8 @@ variable "elasticsearch_modsec_audit_host" {
   description = "The elasticsearch host where modsec audit logs are going to be shipped"
 }
 
-variable "elasticsearch_audit_host" {
-  description = "The elasticsearch audit host where logs are going to be shipped"
-}
-
 variable "enable_fluent_bit" {
   description = "Enable or not fluent-bit Helm Chart - change the default to true once it is ready to use"
   default     = true
-  type        = bool
-}
-
-variable "enable_curator_cronjob" {
-  description = "Enable or not elastic-search curator cronjob - which runs every day to delete indices older than 30 days"
-  default     = false
   type        = bool
 }


### PR DESCRIPTION
This is no longer used, and the last log we hold in ElasticSearch from this integration is from April 2022.