### PR TITLE
Hotfix mem buf limit err

### DIFF
--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -57,7 +57,7 @@ config:
   service: |
     [SERVICE]
         Flush         1
-        Log_Level     debug
+        Log_Level     info
         Daemon        Off
         Parsers_File  parsers.conf
         Parsers_File  custom_parsers.conf

--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -78,6 +78,7 @@ config:
 
     [INPUT]
         Name                              tail
+        Alias                             user_app_data
         Tag                               kubernetes.*
         Path                              /var/log/containers/*.log
         Exclude_Path                      *nx-*.log,eventrouter-*.log
@@ -97,6 +98,7 @@ config:
 
     [INPUT]
         Name                              tail
+        Alias                             default_nginx_ingress
         Tag                               nginx-ingress.*
         Path                              /var/log/containers/*nx-*.log
         Parser                            cri-containerd
@@ -111,6 +113,7 @@ config:
 
     [INPUT]
         Name                              tail
+        Alias                             modsec_nginx_ingress
         Tag                               cp-ingress-modsec.*
         Path                              /var/log/containers/*nx-*.log
         Parser                            cri-containerd
@@ -125,6 +128,7 @@ config:
 
     [INPUT]
         Name                              tail
+        Alias                             eventrouter
         Tag                               eventrouter.*
         Path                              /var/log/containers/eventrouter-*.log
         Parser                            generic-json
@@ -137,6 +141,7 @@ config:
 
     [INPUT]
         Name                              tail
+        Alias                             kube_apiserver_audit
         Tag                               kube-apiserver-audit.*
         Path                              /var/log/kube-apiserver-audit.log
         Parser                            cri-containerd
@@ -151,6 +156,7 @@ config:
 
     [FILTER]
         Name                kubernetes
+        Alias               user_app_data
         Match               kubernetes.*
         Kube_Tag_Prefix     kubernetes.var.log.containers.
         Kube_URL            https://kubernetes.default.svc:443
@@ -163,6 +169,7 @@ config:
 
     [FILTER]
         Name                kubernetes
+        Alias               eventrouter
         Match               eventrouter.*
         Kube_Tag_Prefix     eventrouter.var.log.containers.
         Kube_URL            https://kubernetes.default.svc:443
@@ -181,6 +188,7 @@ config:
         Exclude             log /.*ModSecurity-nginx.*/
     [FILTER]
         Name                kubernetes
+        Alias               default_nginx_ingress
         Match               nginx-ingress.*
         Kube_Tag_Prefix     nginx-ingress.var.log.containers.
         Kube_URL            https://kubernetes.default.svc:443
@@ -199,6 +207,7 @@ config:
         regex               log (ModSecurity-nginx|modsecurity|OWASP_CRS|owasp-modsecurity-crs)
     [FILTER]
         Name                kubernetes
+        Alias               modsec_nginx_ingress
         Match               cp-ingress-modsec.*
         Kube_Tag_Prefix     cp-ingress-modsec.var.log.containers.
         Kube_URL            https://kubernetes.default.svc:443
@@ -218,6 +227,7 @@ config:
 
     [OUTPUT]
         Name                      es
+        Alias                     user_app_data
         Match                     kubernetes.*
         Host                      search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com
         Port                      443
@@ -234,6 +244,7 @@ config:
 
     [OUTPUT]
         Name                      es
+        Alias                     default_nginx_ingress
         Match                     nginx-ingress.*
         Host                      search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com
         Port                      443
@@ -249,6 +260,7 @@ config:
 
     [OUTPUT]
         Name                      opensearch
+        Alias                     modsec_nginx_ingress
         Match                     cp-ingress-modsec.*
         Host                      search-cp-live-modsec-audit-nuhzlrjwxrmdd6op3mvj2k5mye.eu-west-2.es.amazonaws.com
         Port                      443
@@ -266,6 +278,7 @@ config:
         Buffer_Size               False
     [OUTPUT]
         Name                      es
+        Alias                     eventrouter
         Match                     eventrouter.*
         Host                      search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com
         Port                      443

--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -3,6 +3,14 @@ image:
   repository: fluent/fluent-bit
   pullPolicy: Always
 
+resources:
+   limits:
+     cpu: 2500m
+     memory: 2500Mi
+   requests:
+     cpu: 600m
+     memory: 900Mi
+
 serviceMonitor:
   enabled: true
   interval: 10s
@@ -56,58 +64,91 @@ luaScripts:
 config:
   service: |
     [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        Off
-        Parsers_File  parsers.conf
-        Parsers_File  custom_parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
-  ## https://docs.fluentbit.io/manual/pipeline/inputs
-  inputs: |
-    [INPUT]
-        Name              tail
-        Tag               kubernetes.*
-        Path              /var/log/containers/*.log
-        Exclude_Path      *nx-*.log,eventrouter-*.log
-        Parser            cri-containerd
-        Refresh_Interval  5
-        Mem_Buf_Limit     12MB
-        Skip_Long_Lines   On
-    [INPUT]
-        Name              tail
-        Tag               nginx-ingress.*
-        Path              /var/log/containers/*nx-*.log
-        Parser            cri-containerd
-        Refresh_Interval  5
-        Mem_Buf_Limit     5MB
-    [INPUT]
-        Name              tail
-        Tag               cp-ingress-modsec.*
-        Path              /var/log/containers/*nx-*.log
-        Parser            cri-containerd
-        Refresh_Interval  5
-        Mem_Buf_Limit     5MB
-    [INPUT]
-        Name              tail
-        Tag               eventrouter.*
-        Path              /var/log/containers/eventrouter-*.log
-        Parser            generic-json
-        Refresh_Interval  5
-        Mem_Buf_Limit     5MB
-    [INPUT]
-        Name              tail
-        Tag               kube-apiserver-audit.*
-        Path              /var/log/kube-apiserver-audit.log
-        Parser            cri-containerd
-        Refresh_Interval  5
-        Mem_Buf_Limit     5MB
-        Buffer_Max_Size   5MB
-        Buffer_Chunk_Size 1M
+        Flush                             1
+        Log_Level                         info
+        Daemon                            Off
+        Parsers_File                      parsers.conf
+        Parsers_File                      custom_parsers.conf
+        HTTP_Server                       On
+        HTTP_Listen                       0.0.0.0
+        HTTP_Port                         2020
+        Storage.path                      /var/log/flb-storage/
+        Storage.max_chunks_up             500
+        Storage.backlog.mem_limit         100MB
 
-  ## https://docs.fluentbit.io/manual/pipeline/filters
-  filters: |
+    [INPUT]
+        Name                              tail
+        Tag                               kubernetes.*
+        Path                              /var/log/containers/*.log
+        Exclude_Path                      *nx-*.log,eventrouter-*.log
+        Parser                            cri-containerd
+        Refresh_Interval                  5
+        Skip_Long_Lines                   On
+        Buffer_Max_Size                   5MB
+        Buffer_Chunk_Size                 1M
+        Offset_Key                        pause_position_kubernetes
+        DB                                kubernetes.db
+        DB.locking                        true
+        ## https://docs.fluentbit.io/manual/administration/buffering-and-storage#filesystem-buffering-to-the-rescue
+        Storage.type                      filesystem
+        ## https://docs.fluentbit.io/manual/administration/backpressure#storage.max_chunks_up
+        Storage.pause_on_chunks_overlimit True
+        Skip_Long_Lines   On
+
+    [INPUT]
+        Name                              tail
+        Tag                               nginx-ingress.*
+        Path                              /var/log/containers/*nx-*.log
+        Parser                            cri-containerd
+        Refresh_Interval                  5
+        Buffer_Max_Size                   5MB
+        Buffer_Chunk_Size                 1M
+        Offset_Key                        pause_position_nginx_ingress
+        DB                                nginx-ingress.db
+        DB.locking                        true
+        Storage.type                      filesystem
+        Storage.pause_on_chunks_overlimit True
+
+    [INPUT]
+        Name                              tail
+        Tag                               cp-ingress-modsec.*
+        Path                              /var/log/containers/*nx-*.log
+        Parser                            cri-containerd
+        Refresh_Interval                  5
+        Buffer_Max_Size                   5MB
+        Buffer_Chunk_Size                 1M
+        Offset_Key                        pause_position_modsec
+        DB                                cp-ingress-modsec.db
+        DB.locking                        true
+        Storage.type                      filesystem
+        Storage.pause_on_chunks_overlimit True
+
+    [INPUT]
+        Name                              tail
+        Tag                               eventrouter.*
+        Path                              /var/log/containers/eventrouter-*.log
+        Parser                            generic-json
+        Refresh_Interval                  5
+        Offset_Key                        pause_position_eventrouter
+        DB                                eventrouter.db
+        DB.locking                        true
+        Storage.type                      filesystem
+        Storage.pause_on_chunks_overlimit True
+
+    [INPUT]
+        Name                              tail
+        Tag                               kube-apiserver-audit.*
+        Path                              /var/log/kube-apiserver-audit.log
+        Parser                            cri-containerd
+        Refresh_Interval                  5
+        Buffer_Max_Size                   5MB
+        Buffer_Chunk_Size                 1M
+        Offset_Key                        pause_position_api
+        DB                                kube-apiserver-audit.db
+        DB.locking                        true
+        Storage.type                      filesystem
+        Storage.pause_on_chunks_overlimit True
+
     [FILTER]
         Name                kubernetes
         Match               kubernetes.*
@@ -119,10 +160,11 @@ config:
         K8S-Logging.Exclude On
         Merge_Log           Off
         Buffer_Size         1MB
+
     [FILTER]
         Name                kubernetes
         Match               eventrouter.*
-        Kube_Tag_Prefix     eventrouter.var.log.containers.eventrouter*
+        Kube_Tag_Prefix     eventrouter.var.log.containers.
         Kube_URL            https://kubernetes.default.svc:443
         Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -132,7 +174,7 @@ config:
         Merge_Log_Key       log_processed
         Buffer_Size         1MB
 
-    # Redaction of fields
+    ## Redaction of fields
     [FILTER]
         Name                grep
         Match               nginx-ingress.*
@@ -140,7 +182,7 @@ config:
     [FILTER]
         Name                kubernetes
         Match               nginx-ingress.*
-        Kube_Tag_Prefix     nginx-ingress.var.log.containers.nginx-ingress*
+        Kube_Tag_Prefix     nginx-ingress.var.log.containers.
         Kube_URL            https://kubernetes.default.svc:443
         Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -150,7 +192,7 @@ config:
         Merge_Log           On
         Merge_Log_Key       log_processed
         Buffer_Size         1MB
-    # Include only Modsecurity audit logs
+    ## Include only Modsecurity audit logs
     [FILTER]
         Name                grep
         Match               cp-ingress-modsec.*
@@ -158,7 +200,7 @@ config:
     [FILTER]
         Name                kubernetes
         Match               cp-ingress-modsec.*
-        Kube_Tag_Prefix     cp-ingress-modsec.var.log.containers.cp-ingress-modsec*
+        Kube_Tag_Prefix     cp-ingress-modsec.var.log.containers.
         Kube_URL            https://kubernetes.default.svc:443
         Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -174,63 +216,68 @@ config:
         script              /fluent-bit/scripts/cb_extract_tag_value.lua
         call                cb_extract_tag_value
 
-  ## https://docs.fluentbit.io/manual/pipeline/outputs
-  outputs: |
     [OUTPUT]
-        Name            es
-        Match           kubernetes.*
-        Host            ${elasticsearch_host}
-        Port            443
-        Type            _doc
-        Time_Key        @timestamp
-        Logstash_Prefix ${cluster}_kubernetes_cluster
-        tls             On
-        Logstash_Format On
-        Replace_Dots    On
-        Generate_ID     On
-        Retry_Limit     False
+        Name                      es
+        Match                     kubernetes.*
+        Host                      search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com
+        Port                      443
+        Type                      _doc
+        Time_Key                  @timestamp
+        Logstash_Prefix           live_kubernetes_cluster
+        tls                       On
+        Logstash_Format           On
+        Replace_Dots              On
+        Generate_ID               On
+        Retry_Limit               False
+        ## Specify the buffer size used to read the response from the Elasticsearch HTTP service
+        Buffer_Size               False
+
     [OUTPUT]
-        Name            es
-        Match           nginx-ingress.*
-        Host            ${elasticsearch_host}
-        Port            443
-        Type            _doc
-        Time_Key        @timestamp
-        Logstash_Prefix ${cluster}_kubernetes_ingress
-        tls             On
-        Logstash_Format On
-        Replace_Dots    On
-        Generate_ID     On
-        Retry_Limit     False
+        Name                      es
+        Match                     nginx-ingress.*
+        Host                      search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com
+        Port                      443
+        Type                      _doc
+        Time_Key                  @timestamp
+        Logstash_Prefix           live_kubernetes_ingress
+        tls                       On
+        Logstash_Format           On
+        Replace_Dots              On
+        Generate_ID               On
+        Retry_Limit               False
+        Buffer_Size               False
+
     [OUTPUT]
-        Name            opensearch
-        Match           cp-ingress-modsec.*
-        Host            ${elasticsearch_modsec_audit_host}
-        Port            443
-        Type            _doc
-        Time_Key        @timestamp
-        Logstash_Prefix ${cluster}_k8s_modsec_ingress
-        tls             On
-        Logstash_Format On
-        Replace_Dots    On
-        Generate_ID     On
-        Retry_Limit     False
-        AWS_AUTH On
-        AWS_REGION eu-west-2
-        Suppress_Type_Name On
+        Name                      opensearch
+        Match                     cp-ingress-modsec.*
+        Host                      search-cp-live-modsec-audit-nuhzlrjwxrmdd6op3mvj2k5mye.eu-west-2.es.amazonaws.com
+        Port                      443
+        Type                      _doc
+        Time_Key                  @timestamp
+        Logstash_Prefix           live_k8s_modsec_ingress
+        tls                       On
+        Logstash_Format           On
+        Replace_Dots              On
+        Generate_ID               On
+        Retry_Limit               False
+        AWS_AUTH                  On
+        AWS_REGION                eu-west-2
+        Suppress_Type_Name        On
+        Buffer_Size               False
     [OUTPUT]
-        Name            es
-        Match           eventrouter.*
-        Host            ${elasticsearch_host}
-        Port            443
-        Type            _doc
-        Time_Key        @timestamp
-        Logstash_Prefix ${cluster}_eventrouter
-        tls             On
-        Logstash_Format On
-        Replace_Dots    On
-        Generate_ID     On
-        Retry_Limit     False
+        Name                      es
+        Match                     eventrouter.*
+        Host                      search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com
+        Port                      443
+        Type                      _doc
+        Time_Key                  @timestamp
+        Logstash_Prefix           live_eventrouter
+        tls                       On
+        Logstash_Format           On
+        Replace_Dots              On
+        Generate_ID               On
+        Retry_Limit               False
+        Buffer_Size               False
 
   ## https://docs.fluentbit.io/manual/pipeline/parsers
   customParsers: |


### PR DESCRIPTION
- Breaching the memory buffer limit caused fluent bit to stop tailing from the source. We have raised the in memory chunk limit to 500 (chunks being a maximum of 2mb) and we are writing logs which breach this limit to the filesystem, so we can pick these up when memory frees up. [This means we no longer drop logs (we get increased data safety) and the performance of storing in memory](https://docs.fluentbit.io/manual/administration/buffering-and-storage#filesystem-buffering-to-the-rescue).

- Introduced a sqlite db to capture where in the log file we pause the tailing so when tailing resumes it can resume from where we left off.

- Fixed a bug where pod lookups were failing with a 404 from the kube API, this was because we were removing the part of the pod name before lookup.

[drastically reduced failed to flush](https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30m,to:now))&_a=(columns:!(_source),filters:!(),index:'167701b0-f8c0-11ec-b95c-1d65c3682287',interval:auto,query:(language:kuery,query:'%22failed%20to%20flush%22'),sort:!()))

see:
https://docs.fluentbit.io/manual/administration/backpressure
https://docs.fluentbit.io/manual/concepts/buffering

Now we are writing to disk our CPU and memory have increased, so we have bumped the resource limits too.