### PR TITLE
style: 💄 regex alphanumeric for int tests

### DIFF
--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -22,8 +22,8 @@ tolerations:
 luaScripts:
   cb_extract_tag_value.lua: |
     function cb_extract_tag_value(tag, timestamp, record)
-      local github_team = string.gmatch(record["log"], '%[tag "github_team=([%a+|%-]*)"%]')
-      local github_team_from_json = string.gmatch(record["log"], '"tags":%[.*"github_team=([%a+|%-]*)".*%]')
+      local github_team = string.gmatch(record["log"], '%[tag "github_team=([%w+|%-]*)"%]')
+      local github_team_from_json = string.gmatch(record["log"], '"tags":%[.*"github_team=([%w+|%-]*)".*%]')
 
       local new_record = record
       local team_matches = {}


### PR DESCRIPTION
We should match alphanumeric characters and not just letters (integration tests mock github_team uses alphanumeric characters)

https://www.lua.org/pil/20.2.html