### PR TITLE
Bump memory limit to fix OOMKilled of fluent-bit pod

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -140,7 +140,7 @@ resource "kubernetes_limit_range" "default" {
       type = "Container"
       default = {
         cpu    = "2"
-        memory = "2500Mi"
+        memory = "3000Mi"
       }
       default_request = {
         cpu    = "100m"


### PR DESCRIPTION
This PR increases the memory limit of the container thereby avoiding fluenbit pod to get OOMKilled. 
https://mojdt.slack.com/archives/C8QR5FQRX/p1696347216264199

