### PR TITLE
perf: ⚡️ remove modsec opensearch & add user app opensearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,6 @@
 # cloud-platform-terraform-logging
 
-Terraform module that deploys cloud-platform logging solution. It includes components like: fluent-bit, eventrouter, circle-ci-stats, etc
-
-## Usage
-
-```hcl
-module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=0.2.0"
-
-  elasticsearch_host       = replace(terraform.workspace, "live", "") != terraform.workspace ? "cloud-platform-live-es-endpoint" : "placeholder-elasticsearch"
-  elasticsearch_audit_host = replace(terraform.workspace, "live", "") != terraform.workspace ? "cloud-platform-audit-es-endpoint" : ""
-
-  dependence_prometheus       = module.prometheus.helm_prometheus_operator_status
-  enable_curator_cronjob      = terraform.workspace == local.live_workspace ? true : false
-  enable_fluent_bit           = true
-}
-```
+Terraform module that deploys cloud-platform logging solution. It includes components like: fluent-bit, eventrouter etc.
 
 <!--- BEGIN_TF_DOCS --->
 ## Requirements

--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -19,38 +19,6 @@ tolerations:
     value: "true"
     effect: "NoSchedule" 
 
-luaScripts:
-  cb_extract_tag_value.lua: |
-    function cb_extract_tag_value(tag, timestamp, record)
-      local github_team = string.gmatch(record["log"], '%[tag "github_team=([%w+|%-]*)"%]')
-      local github_team_from_json = string.gmatch(record["log"], '"tags":%[.*"github_team=([%w+|%-]*)".*%]')
-
-      local new_record = record
-      local team_matches = {}
-      local json_matches = {}
-
-      for team in github_team do
-        table.insert(team_matches, team)
-      end
-
-      for team in github_team_from_json do
-        table.insert(json_matches, team)
-      end
-
-      if #team_matches > 0 then
-        new_record["github_teams"] = team_matches
-        return 1, timestamp, new_record
-
-      elseif #json_matches > 0 then
-        new_record["github_teams"] = json_matches
-
-        return 1, timestamp, new_record
-
-      else
-        return 0, timestamp, record
-      end
-    end
-
 ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file
 config:
   service: |


### PR DESCRIPTION
fluent bit was having issues dropping modsec logs when there were 2 opensearch outputs defined, move modsec log closer to modsec and with other aspects of modsec logging by the ingress controllers

and push user app logs to our new open search cluster