### PR TITLE
Remove lua

### DIFF
--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -120,12 +120,6 @@ config:
         K8S-Logging.Exclude On
         Merge_Log           Off
         Buffer_Size         1MB
-    [FILTER]
-        Name lua
-        Alias user_app_data_os
-        Match kubernetes.*
-        script  /fluent-bit/scripts/cb_extract_team_values.lua
-        call cb_extract_team_values
 
     ## Redaction of fields
     [FILTER]

--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -27,29 +27,6 @@ securityContext:
     drop:
       - NET_RAW
 
-luaScripts:
-  cb_extract_team_values.lua: |
-    function cb_extract_team_values(tag, timestamp, record)
-      if record["kubernetes"]["annotations"]["github_teams"] == nil or record["kubernetes"]["annotations"]["github_teams"] == '' then
-        record["kubernetes"]["annotations"]["github_teams"] = "all-org-members"
-      end
-      local github_team = string.gmatch(record["kubernetes"]["annotations"]["github_teams"], "[^_]+")
-
-      local new_record = record
-      local team_matches = {}
-
-      for team in github_team do
-        table.insert(team_matches, team)
-      end
-
-      if #team_matches > 0 then
-        new_record["github_teams"] = team_matches
-        return 1, timestamp, new_record
-      else
-        return 0, timestamp, record
-      end
-    end
-
 ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file
 config:
   service: |


### PR DESCRIPTION
fluent-bit crashlooping debugging 1: disable luascript team vals config, we are seeing errors in live logs:

`[2024/05/13 10:43:32] [error] [filter:lua:user_app_data_os] error code 2: /fluent-bit/scripts/cb_extract_team_values.lua:2: attempt to index field 'annotations' (a nil value)`


