### PR TITLE
fix: 🐛 rollback fluentbit to 2.2.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "helm_release" "fluent_bit" {
   chart      = "fluent-bit"
   repository = "https://fluent.github.io/helm-charts"
   namespace  = kubernetes_namespace.logging.id
-  version    = "0.46.2"
+  version    = "0.42.0"
   timeout    = 1500
 
   values = [templatefile("${path.module}/templates/fluent-bit.yaml.tpl", {


### PR DESCRIPTION
since upgrading to 3.0.2 we are seeing freqeunt crashloops. roll back for stability until 3 issues resolved