### PR TITLE
fix: 🐛 revert lua and add default value github_teams anno

### DIFF
--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -27,6 +27,40 @@ securityContext:
     drop:
       - NET_RAW
 
+luaScripts:
+  cb_extract_team_values.lua: |
+    function cb_extract_team_values(tag, timestamp, record)
+      local new_record = record
+
+      if record["kubernetes"]["annotations"] ~= nil then
+        new_record["kubernetes"]["annotations"] = {}
+        new_record["kubernetes"]["annotations"]["github_teams"] = "all-org-members"
+
+        return 1, timestamp, new_record
+      end
+
+      if record["kubernetes"]["annotations"]["github_teams"] ~= nil or record["kubernetes"]["annotations"]["github_teams"] == '' then
+        record["kubernetes"]["annotations"]["github_teams"] = "all-org-members"
+
+        return 1, timestamp, new_record
+      end
+
+      local github_team = string.gmatch(record["kubernetes"]["annotations"]["github_teams"], "[^_]+")
+
+      local team_matches = {}
+
+      for team in github_team do
+        table.insert(team_matches, team)
+      end
+
+      if #team_matches > 0 then
+        new_record["github_teams"] = team_matches
+        return 1, timestamp, new_record
+      else
+        return 0, timestamp, record
+      end
+    end
+
 ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file
 config:
   service: |
@@ -120,6 +154,13 @@ config:
         K8S-Logging.Exclude On
         Merge_Log           Off
         Buffer_Size         1MB
+
+    [FILTER]
+        Name lua
+        Alias user_app_data_os
+        Match kubernetes.*
+        script  /fluent-bit/scripts/cb_extract_team_values.lua
+        call cb_extract_team_values
 
     ## Redaction of fields
     [FILTER]


### PR DESCRIPTION
- tag each log by reading the `github_teams` annotation and reformatting it
- if annotation doesn't exist apply default `all-org-members`