### PR TITLE
Revert "chore: 🤖 temp disabling of opensearch output, filter and lua"

### DIFF
--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -157,6 +157,13 @@ config:
         Merge_Log           Off
         Buffer_Size         1MB
 
+    [FILTER]
+        Name lua
+        Alias user_app_data_os
+        Match kubernetes.*
+        script  /fluent-bit/scripts/cb_extract_team_values.lua
+        call cb_extract_team_values
+
     ## Redaction of fields
     [FILTER]
         Name                grep
@@ -228,6 +235,62 @@ config:
         Retry_Limit               False
         Buffer_Size               False
 
+    [OUTPUT]
+        Name                      opensearch
+        Alias                     user_app_data_os
+        Match                     kubernetes.*
+        Host                      ${opensearch_app_host}
+        Port                      443
+        Type                      _doc
+        Time_Key                  @timestamp
+        Logstash_Prefix           ${cluster}_kubernetes_cluster
+        tls                       On
+        Logstash_Format           On
+        Replace_Dots              On
+        Generate_ID               On
+        Retry_Limit               False
+        AWS_AUTH                  On
+        AWS_REGION                eu-west-2
+        Suppress_Type_Name        On
+        Buffer_Size               False
+
+    [OUTPUT]
+        Name                      opensearch
+        Alias                     default_nginx_ingress_os
+        Match                     nginx-ingress.*
+        Host                      ${opensearch_app_host}
+        Port                      443
+        Type                      _doc
+        Time_Key                  @timestamp
+        Logstash_Prefix           ${cluster}_kubernetes_ingress
+        tls                       On
+        Logstash_Format           On
+        Replace_Dots              On
+        Generate_ID               On
+        Retry_Limit               False
+        AWS_AUTH                  On
+        AWS_REGION                eu-west-2
+        Suppress_Type_Name        On
+        Buffer_Size               False
+
+    [OUTPUT]
+        Name                      opensearch
+        Alias                     eventrouter_os
+        Match                     eventrouter.*
+        Host                      ${opensearch_app_host}
+        Port                      443
+        Type                      _doc
+        Time_Key                  @timestamp
+        Logstash_Prefix           ${cluster}_eventrouter
+        tls                       On
+        Logstash_Format           On
+        Replace_Dots              On
+        Generate_ID               On
+        Retry_Limit               False
+        AWS_AUTH                  On
+        AWS_REGION                eu-west-2
+        Suppress_Type_Name        On
+        Buffer_Size               False
 
   ## https://docs.fluentbit.io/manual/pipeline/parsers
   customParsers: |


### PR DESCRIPTION
## 👀 Purpose

- Reverts disabling opensearch in fluent-bit

## ♻️ What's changed

- Re-added output sections to fluent-bit conf

## 📝 Notes

-This reverts commit 7242a59a8fbb05903915a6eb59ee48f71cb1296e.