### PR TITLE
upgrade helm logging images from 0.42.0 to 0.48.2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "helm_release" "fluent_bit" {
   chart      = "fluent-bit"
   repository = "https://fluent.github.io/helm-charts"
   namespace  = kubernetes_namespace.logging.id
-  version    = "0.42.0"
+  version    = "0.48.2"
   timeout    = 1500
 
   values = [templatefile("${path.module}/templates/fluent-bit.yaml.tpl", {


### PR DESCRIPTION
Relates to https://github.com/orgs/ministryofjustice/projects/65/views/3?filterQuery=+sprint%3A%40current+&pane=issue&itemId=88993204&issue=ministryofjustice%7Ccloud-platform%7C6510