### PR TITLE
fix: 🐛 use Current_Time_Index

### DIFF
--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -209,7 +209,7 @@ config:
         Port                      443
         Type                      _doc
         Time_Key                  @timestamp
-        Current_Time_index        On
+        Current_Time_Index        On
         Logstash_Prefix           ${cluster}_kubernetes_cluster
         tls                       On
         Logstash_Format           On
@@ -229,7 +229,7 @@ config:
         Port                      443
         Type                      _doc
         Time_Key                  @timestamp
-        Current_Time_index        On
+        Current_Time_Index        On
         Logstash_Prefix           ${cluster}_kubernetes_ingress
         tls                       On
         Logstash_Format           On
@@ -249,7 +249,7 @@ config:
         Port                      443
         Type                      _doc
         Time_Key                  @timestamp
-        Current_Time_index        On
+        Current_Time_Index        On
         Logstash_Prefix           ${cluster}_eventrouter
         tls                       On
         Logstash_Format           On
@@ -269,7 +269,7 @@ config:
         Port                      443
         Type                      _doc
         Time_Key                  @timestamp
-        Current_Time_index        On
+        Current_Time_Index        On
         Logstash_Prefix           ${cluster}_ipamd
         tls                       On
         Logstash_Format           On

--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -209,6 +209,7 @@ config:
         Port                      443
         Type                      _doc
         Time_Key                  @timestamp
+        Current_Time_index        On
         Logstash_Prefix           ${cluster}_kubernetes_cluster
         tls                       On
         Logstash_Format           On
@@ -228,6 +229,7 @@ config:
         Port                      443
         Type                      _doc
         Time_Key                  @timestamp
+        Current_Time_index        On
         Logstash_Prefix           ${cluster}_kubernetes_ingress
         tls                       On
         Logstash_Format           On
@@ -247,6 +249,7 @@ config:
         Port                      443
         Type                      _doc
         Time_Key                  @timestamp
+        Current_Time_index        On
         Logstash_Prefix           ${cluster}_eventrouter
         tls                       On
         Logstash_Format           On
@@ -265,7 +268,7 @@ config:
         Host                      ${opensearch_app_host}
         Port                      443
         Type                      _doc
-        Time_Key                  time
+        Time_Key                  @timestamp
         Current_Time_index        On
         Logstash_Prefix           ${cluster}_ipamd
         tls                       On


### PR DESCRIPTION
- I have tested on ipamd and the index is created properly with this flag on, trial this method (current time on the server) of created the date for the index instead of reading it from the log

https://docs.fluentbit.io/manual/pipeline/outputs/opensearch

![image](https://github.com/user-attachments/assets/467156b5-6110-4b6f-bd56-6c9dd7930a76)
