### PR TITLE
chore: 🤖 0.42.0 -> 0.48.9 helm chart bump

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "helm_release" "fluent_bit" {
   chart      = "fluent-bit"
   repository = "https://fluent.github.io/helm-charts"
   namespace  = kubernetes_namespace.logging.id
-  version    = "0.42.0"
+  version    = "0.48.9"
   timeout    = 1500
 
   values = [templatefile("${path.module}/templates/fluent-bit.yaml.tpl", {


### PR DESCRIPTION
- tested on a test cluster, upgrade went smoothly (be prepared to roll back in live though as this is a major version change that failed previously app version 2.2.1 -> 3.2.8)