### PR TITLE
Debug timestamp logs 2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -120,8 +120,8 @@ resource "kubernetes_limit_range" "default" {
     limit {
       type = "Container"
       default = {
-        cpu    = "2"
-        memory = "3500Mi"
+        cpu    = "4"
+        memory = "5500Mi"
       }
       default_request = {
         cpu    = "100m"

--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -122,7 +122,6 @@ config:
         Alias                             eventrouter
         Tag                               eventrouter.*
         DB                                eventrouter.db
-        DB.locking                        true
         # ask k8s API for updates every x seconds
         interval_sec                      60
         # fetch at most x items per requests (pagination)
@@ -222,6 +221,7 @@ config:
         AWS_REGION                eu-west-2
         Suppress_Type_Name        On
         Buffer_Size               False
+        Workers                   2
 
     [OUTPUT]
         Name                      opensearch
@@ -242,6 +242,7 @@ config:
         AWS_REGION                eu-west-2
         Suppress_Type_Name        On
         Buffer_Size               False
+        Workers                   2
 
     [OUTPUT]
         Name                      opensearch
@@ -262,6 +263,7 @@ config:
         AWS_REGION                eu-west-2
         Suppress_Type_Name        On
         Buffer_Size               False
+        Workers                   1
 
     [OUTPUT]
         Name                      opensearch

--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -118,6 +118,19 @@ config:
         Storage.pause_on_chunks_overlimit True
 
     [INPUT]
+        Name                              kubernetes_events
+        Alias                             eventrouter
+        Tag                               eventrouter.*
+        DB                                eventrouter.db
+        DB.locking                        true
+        # ask k8s API for updates every x seconds
+        interval_sec                      60
+        # fetch at most x items per requests (pagination)
+        kube_request_limit                250
+        Storage.type                      filesystem
+        Storage.pause_on_chunks_overlimit True
+
+    [INPUT]
         Name                              tail
         Alias                             kube_apiserver_audit
         Tag                               kube-apiserver-audit.*
@@ -220,6 +233,26 @@ config:
         Time_Key                  @timestamp
         Current_Time_Index        On
         Logstash_Prefix           ${cluster}_kubernetes_ingress
+        tls                       On
+        Logstash_Format           On
+        Replace_Dots              On
+        Generate_ID               On
+        Retry_Limit               False
+        AWS_AUTH                  On
+        AWS_REGION                eu-west-2
+        Suppress_Type_Name        On
+        Buffer_Size               False
+
+    [OUTPUT]
+        Name                      opensearch
+        Alias                     eventrouter_os
+        Match                     eventrouter.*
+        Host                      ${opensearch_app_host}
+        Port                      443
+        Type                      _doc
+        Time_Key                  @timestamp
+        Current_Time_Index        On
+        Logstash_Prefix           ${cluster}_eventrouter
         tls                       On
         Logstash_Format           On
         Replace_Dots              On


### PR DESCRIPTION
- add back kubernetes_events
- add isolated threads for write heavy indexes https://docs.fluentbit.io/manual/administration/multithreading