### PR TITLE
fix: 🐛 exclude modsec access logs

### DIFF
--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -106,7 +106,8 @@ config:
         Alias                             default_nginx_ingress
         Tag                               nginx-ingress.*
         Path                              /var/log/containers/*nx-*.log
-        Parser                            generic-json, cri-containerd
+        Exclude_Path                      /var/log/containers/*nginx-ingress-modsec-*controller*_ingress-controllers_*.log
+        Parser                            cri-containerd
         Refresh_Interval                  5
         Skip_Long_Lines                   On
         Buffer_Max_Size                   5MB
@@ -199,7 +200,6 @@ config:
         Merge_Log           On
         Merge_Log_Key       log_processed
         Buffer_Size         1MB
-
 
   outputs: |
     [OUTPUT]


### PR DESCRIPTION
- we are shipping modsec controller access logs to opensearch app logs from the ingress controller flb now. We don't need to also tail them here
- generic-json isn't parsing the log as it isn't json