### PR TITLE
feat: 🎸 Adding S3 output for application logs for Cortex XSIAM ingestion

### DIFF
--- a/serviceaccount.tf
+++ b/serviceaccount.tf
@@ -22,9 +22,15 @@ resource "kubernetes_service_account" "this" {
   metadata {
     name      = local.sa_name
     namespace = local.namespace
+    annotations = {
+      "eks.amazonaws.com/role-arn" = module.iam_assumable_role.iam_role_arn
+    }    
   }
 
-  depends_on = [kubernetes_namespace.logging]
+  depends_on = [
+    kubernetes_namespace.logging,
+    module.iam_assumable_role
+  ]
 }
 
 resource "kubernetes_cluster_role" "this" {

--- a/templates/fluent-bit.yaml.tpl
+++ b/templates/fluent-bit.yaml.tpl
@@ -280,6 +280,20 @@ config:
         Suppress_Type_Name                On
         Buffer_Size                       False
 
+    [OUTPUT]
+        Name                              s3
+        Alias                             user_app_data_s3
+        Match                             kubernetes.*
+        bucket                            ${s3_bucket_application_logs}
+        region                            eu-west-2
+        total_file_size                   5M
+        upload_timeout                    10m
+        store_dir                         /tmp/fluent-bit/s3
+        store_dir_limit_size              1G
+        s3_key_format                     /logs/%Y/%m/%d/%H/%M/%S-$UUID
+        use_put_object                    true
+        Retry_Limit                       False            
+
   ## https://docs.fluentbit.io/manual/pipeline/parsers
   customParsers: |
     [PARSER]


### PR DESCRIPTION
This PR will do the following:

- Attach IRSA annotation to existing service account
- Add Output data pipeline to ship application logs to the S3 bucket

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7204