### PR TITLE
chore: 🤖 increase pod hard limit for daemonset

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,7 @@ resource "kubernetes_resource_quota" "namespace_quota" {
   }
   spec {
     hard = {
-      pods = 100
+      pods = 130
     }
   }
 }


### PR DESCRIPTION
## Purpose

Increase hard pod limit to resolve LPA alerts:

```
warning: KubeQuota-Exceeded
Alert: Namespace logging is using 91% of its pods quota.
```
