### PR TITLE
chore: increase logging namespace pod quota to 170

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,7 @@ resource "kubernetes_resource_quota" "namespace_quota" {
   }
   spec {
     hard = {
-      pods = 150
+      pods = 170
     }
   }
 }


### PR DESCRIPTION
## What

Increase the pod quota for the `logging` namespace from 150 to 170.

## Why

The `KubeQuota-Exceeded` alert fired, the logging namespace is at 138/150 pods (92%). All pods are from the `fluent-bit` DaemonSet (one per node). With 138 nodes and a quota of 150, there are only 12 pods of headroom. Bumping to 170 provides sufficient room for cluster growth and could be reduced once the cluster work being undergone by the team is concluded.

## Evidence

```
$ kubectl get resourcequota namespace-quota -n logging
NAME              REQUEST         LIMIT   AGE
namespace-quota   pods: 138/150           4y300d
```

[Lower Priority Alarm](https://mojdt.slack.com/archives/C8QR5FQRX/p1776997240852919)